### PR TITLE
Updated to fix state colours

### DIFF
--- a/themes/caule-themes-pack-1.yaml
+++ b/themes/caule-themes-pack-1.yaml
@@ -120,7 +120,14 @@ Caule Black Rose:
   sidebar-selected-text-color: var(--sidebar-selected-icon-color)
   # Icons colors
   state-icon-color: var(--disabled-color)
-  state-icon-active-color: var(--primary-color)
+  state-switch-color: var(--primary-color)
+  state-automation-color: var(--primary-color)
+  state-cover-color: var(--primary-color)
+  state-fan-color: var(--primary-color)
+  state-light-color: var(--primary-color)
+  state-person-home-color: var(--primary-color)
+  badge-person-not-home-color: var(--primary-color)
+  state-person-zone-color: var(--primary-color)
   state-icon-unavailable-color: var(--primary-background-color)
   # Settins and colors of Mini Media Player
   mini-media-player-icon-color: var(--primary-color)


### PR DESCRIPTION
HA's 2022.12 update broke the state colours for all themes that change them. I have implemented a basic fix to return the themes to how they looked before the update.

New values were taken from here: https://community.home-assistant.io/t/2022-12-color-states-are-broken-unusable/499890/3